### PR TITLE
Change gammas API

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,15 @@
 History
 =======
 
+0.1.2 (Current version)
+-----------------------
+
+* :py:func:`impax.csvv.get_gammas` has been deprecated. Use :py:func:`impax.read_csvv` instead (:issue:`37`)
+* :py:meth:`~impax.csvv.Gammas._prep_gammas` has been removed, and :py:meth:`~impax.csvv.Gammas.sample` now
+  takes no arguments and returns a sample by default. Seeding the random number generator is now left up to
+  the user (:issue:`36`)
+
+
 0.1.0 (2017-10-12)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ History
 * :py:meth:`~impax.csvv.Gammas._prep_gammas` has been removed, and :py:meth:`~impax.csvv.Gammas.sample` now
   takes no arguments and returns a sample by default. Seeding the random number generator is now left up to
   the user (:issue:`36`)
+* fix py3k compatability issues (:issue:`39`)
+* fix travis status icon in README
 
 
 0.1.0 (2017-10-12)

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ impax
 .. image:: https://img.shields.io/pypi/v/impax.svg
         :target: https://pypi.python.org/pypi/impax
 
-.. image:: https://img.shields.io/travisClimateImpactLab/impax.svg
+.. image:: https://img.shields.io/travis/ClimateImpactLab/impax.svg
         :target: https://travis-ci.org/ClimateImpactLab/impax
 
 .. image:: https://readthedocs.org/projects/impax/badge/?version=latest

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,1 @@
-/impax.rst
 /impax.*.rst
-/modules.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
     'sphinx.ext.napoleon',
-    'sphinx.ext.intersphinx']
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.mathjax']
 
 extlinks = {
     'issue': ('https://github.com/ClimateImpactLab/impax/issues/%s', 'GH #'),
@@ -289,5 +290,8 @@ texinfo_documents = [
 
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/2.7', None)
+    'python': ('https://docs.python.org/2.7', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+    'xarray': ('http://xarray.pydata.org/en/latest', None)
 }

--- a/docs/impax.rst
+++ b/docs/impax.rst
@@ -1,0 +1,47 @@
+impax package
+=============
+
+Submodules
+----------
+
+impax\.cli module
+-----------------
+
+.. automodule:: impax.cli
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+impax\.estimate module
+----------------------
+
+.. automodule:: impax.estimate
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+impax\.impax module
+-------------------
+
+.. automodule:: impax.impax
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+impax\.mins module
+------------------
+
+.. automodule:: impax.mins
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: impax
+    :noindex:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+impax
+=====
+
+.. toctree::
+   :maxdepth: 4
+
+   impax

--- a/impax/__init__.py
+++ b/impax/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from impax.mins import minimize_polynomial
-from impax.csvv import get_gammas
+from impax.csvv import read_csvv
 from impax.impax import construct_covars, construct_weather
 
 __author__ = """Justin Simcock"""
@@ -12,7 +12,7 @@ _module_imports = (
     minimize_polynomial,
     construct_covars,
     construct_weather, 
-    get_gammas
+    read_csvv
 )
 
 __all__ = list(map(lambda x: x.__name__, _module_imports))

--- a/impax/__init__.py
+++ b/impax/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from impax.mins import minimize_polynomial
-from impax.csvv import read_csvv
+from impax.estimate import read_csvv, MultivariateNormalEstimator
 from impax.impax import construct_covars, construct_weather
 
 __author__ = """Justin Simcock"""
@@ -12,7 +12,8 @@ _module_imports = (
     minimize_polynomial,
     construct_covars,
     construct_weather, 
-    read_csvv
+    read_csvv,
+    MultivariateNormalEstimator
 )
 
 __all__ = list(map(lambda x: x.__name__, _module_imports))

--- a/impax/csvv.py
+++ b/impax/csvv.py
@@ -5,6 +5,8 @@ import pandas as pd
 import numpy as np
 from scipy.stats import multivariate_normal as mn
 
+import warnings
+
 
 def read_csvv(csvv_path):
     '''
@@ -100,5 +102,8 @@ class Gammas(object):
             :py:class:`~xarray.DataArray` of parameter estimates drawn from the multivariate normal
 
         '''
+        if seed is not None:
+            warnings.warn('Sampling with a seed has been deprecated. In future releases, this will be up to the user.', DeprecationWarning)
+            np.random.seed(seed)
 
         return pd.Series(mn.rvs(self.gammas, self.gammavcv), index=self.index).to_xarray()

--- a/impax/estimate.py
+++ b/impax/estimate.py
@@ -31,20 +31,21 @@ def read_csvv(csvv_path):
 
         for row in reader:
             if row[0] == 'gamma':
-                data['gamma'] = np.array([float(i) for i in reader.next()])
+                data['gamma'] = np.array([float(i) for i in next(reader)])
             if row[0] == 'gammavcv':
-                data['gammavcv'] = np.array([float(i) for i in reader.next()])
+                data['gammavcv'] = np.array([float(i) for i in next(reader)])
             if row[0] == 'residvcv':
-                data['residvcv'] = np.array([float(i) for i in reader.next()])
+                data['residvcv'] = np.array([float(i) for i in next(reader)])
             if row[0] == 'prednames':
-                data['prednames'] = [i.strip() for i in reader.next()]
+                data['prednames'] = [i.strip() for i in next(reader)]
             if row[0] == 'covarnames':
-                data['covarnames'] = [i.strip() for i in reader.next()]
+                data['covarnames'] = [i.strip() for i in next(reader)]
             if row[0] == 'outcome': 
-                data['outcome'] =[cv.strip() for cv in reader.next()]
+                data['outcome'] =[cv.strip() for cv in next(reader)]
 
-    index = pd.MultiIndex.from_tuples(zip(data['outcome'], data['prednames'], data['covarnames']), 
-                                            names=['outcome', 'prednames', 'covarnames'])
+    index = pd.MultiIndex.from_tuples(
+        list(zip(data['outcome'], data['prednames'], data['covarnames'])), 
+        names=['outcome', 'prednames', 'covarnames'])
 
     g = MultivariateNormalEstimator(data['gamma'], data['gammavcv'], index)
 

--- a/impax/estimate.py
+++ b/impax/estimate.py
@@ -64,13 +64,13 @@ class MultivariateNormalEstimator(object):
     Parameters
     ----------
     coefficients: array 
-        length $(m1*m2*...*mn)$ 1-d :py:class:`~numpy.array` with regression coefficients
+        length :math:`(m_1*m_2*\cdots*m_n)` 1-d :py:class:`numpy.ndarray` with regression coefficients
 
     vcv: array
-        $(m1*m2*...*mn)x(m1*m2*...*mn)$ :py:class:`~numpy.array` with variance-covariance matrix for multivariate distribution
+        :math:`(m_1*m_2*\cdots*m_n) x (m_1*m_2*\cdots*m_n)` :py:class:`numpy.ndarray` with variance-covariance matrix for multivariate distribution
 
     index: Index
-        :py:class:`~pandas.Index` or $(m1*m2*...*mn)$ 1-d :py:class:`~pandas.MultiIndex` describing the multivariate space
+        :py:class:`~pandas.Index` or :math:`(m_1*m_2*\cdots*m_n)` 1-d :py:class:`~pandas.MultiIndex` describing the multivariate space
 
     '''
 
@@ -85,8 +85,8 @@ class MultivariateNormalEstimator(object):
 
         Returns
         -------
-        median : xarray.DataArray
-            :py:class `~xarray.DataArray` of coefficients
+        median : DataArray
+            :py:class:`~xarray.DataArray` of coefficients
         '''
 
         return pd.Series(self.coefficients, index=self.index).to_xarray()
@@ -100,7 +100,7 @@ class MultivariateNormalEstimator(object):
 
         Returns
         ----------
-        draw : xarray.DataArray
+        draw : DataArray
             :py:class:`~xarray.DataArray` of parameter estimates drawn from the multivariate normal
 
         '''

--- a/impax/impax.py
+++ b/impax/impax.py
@@ -139,27 +139,15 @@ class Impact(object):
         weather: DataArray
           weather :py:class:`~xarray.DataArray`
 
-        gammas: DataArray
-          covarname by outcome py:class:`~xarray.DataArray`
-
-        gdp_covar: DataArray
-          hierid by gdp :py:class:`~xarray.DataArray`
-
-        clim_covar: DataArray
-          hierid by predname :py:class:`~xarray.DataArray`
-
-        baseline: :py:class:`~xarray.Dataset`
-          precomputed avg baseline impact for impacts between base years
-
-        bounds: list
-          list of values to compute mins for computing m-star
+        betas: DataArray
+          covarname by outcome :py:class:`~xarray.DataArray`
          
         clip_flat_curve: bool
           flag indicating that flat-curve clipping should be performed
           on the result
 
-        t_star_path: str
-          unformatted string path to designate read/write location for t_star
+        t_star: DataArray
+          :py:class:`xarray.DataArray` with minimum temperatures used for clipping
 
 
         Returns

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,2 @@
 click==6.7
-pandas==20.3
-xarray==0.9.6
-scipy==1.0
-numpy==1.13.3
-toolz==0.8.2
 


### PR DESCRIPTION
 - [x] closes #36, #37, and #39 
 - [ ] tests added / passed # no testing suite yet
 - [x] docs reflect changes
 - [x] passes ``flake8 impax tests docs``
 - [x] entry in HISTORY.rst

A couple changes in this commit:

* deprecated get_gammas in favor of read_csvv for clarity and to follow xarray/pandas/numpy naming conventions. get_gammas is retained for now with a deprecation warning.
* sample() now returns an estimate, median() returns the median, and _prep_gammas is removed. sample() returning a median by default risked confusion. Providing a seed is now up to the user. Sampling with a seed is retained for now with a deprecation warning.
* additional pep8 and documentation updates